### PR TITLE
Fixing type error

### DIFF
--- a/scripts/cachePosts.ts
+++ b/scripts/cachePosts.ts
@@ -100,7 +100,7 @@ getPages();
 
 if (process.argv.at(-1) === 'watch') {
 	watch('./content', (eventType, filename) => {
-		if (filename.endsWith('.mdx')) {
+		if (filename?.endsWith('.mdx')) {
 			getPosts();
 		}
 	});


### PR DESCRIPTION
A error occurs on the build. 
`scripts/cachePosts.ts:103:7 - error TS18047: 'filename' is possibly 'null'.`

<!--

👋 Hey, thanks for helping to improve Remix Blog!

Our bandwidth on maintaining this stacs is limited. I'm currently focusing my efforts 
on several projects. The good news is you can fork and adjust this stack however 
you'd like and start using it today as a custom stack. Learn more from
[the Remix Stacks docs](https://remix.run/stacks).

If you'd still like to report a bug, please fill out this form. We can't
promise a timely response, but hopefully when we have the bandwidth to
work on these stacks again we can take a look. Thanks!
-->
